### PR TITLE
Add support to persist cookies for multiple calls

### DIFF
--- a/httpcheck.go
+++ b/httpcheck.go
@@ -46,6 +46,7 @@ func New(t *testing.T, handler http.Handler, addr string) *Checker {
 		prefix = "http://" + addr
 	}
 
+	jar, _ := cookiejar.New(nil)
 	instance := &Checker{
 		t:       t,
 		handler: handler,
@@ -53,6 +54,7 @@ func New(t *testing.T, handler http.Handler, addr string) *Checker {
 		prefix:  prefix,
 		client: &http.Client{
 			Timeout: time.Duration(5 * time.Second),
+			Jar:     jar,
 		},
 		persist: false,
 	}
@@ -135,7 +137,7 @@ func (c *Checker) HasHeader(key, expectedValue string) *Checker {
 // Will put cookie on request
 func (c *Checker) HasCookie(key, expectedValue string) *Checker {
 	found := false
-	for _, cookie := range c.response.Cookies() {
+	for _, cookie := range c.client.Jar.Cookies(c.request.URL) {
 		if cookie.Name == key && cookie.Value == expectedValue {
 			found = true
 			break

--- a/httpcheck_test.go
+++ b/httpcheck_test.go
@@ -51,6 +51,15 @@ func (t *testHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		w.Write(body)
 	case "/byte":
 		w.Write([]byte("hello world"))
+	case "/cookies":
+		http.SetCookie(w, &http.Cookie{
+			Name:  "some",
+			Value: "cookie",
+		})
+		http.SetCookie(w, &http.Cookie{
+			Name:  "other",
+			Value: "secondcookie",
+		})
 	case "/nothing":
 
 	}
@@ -268,10 +277,11 @@ func TestCookies(t *testing.T) {
 	checker := makeTestChecker(mockT)
 	checker.PersistCookie("some")
 
-	checker.Test("GET", "/some")
+	checker.Test("GET", "/cookies")
 	checker.Check()
 
 	checker.HasCookie("some", "cookie")
+	checker.HasCookie("other", "secondcookie")
 	assert.False(t, mockT.Failed())
 
 	checker.Test("GET", "/nothing")
@@ -279,21 +289,7 @@ func TestCookies(t *testing.T) {
 
 	checker.HasCookie("some", "cookie")
 	assert.False(t, mockT.Failed())
-}
 
-func TestCookiesDelete(t *testing.T) {
-	mockT := new(testing.T)
-	checker := makeTestChecker(mockT)
-
-	checker.Test("GET", "/some")
-	checker.Check()
-
-	checker.HasCookie("some", "cookie")
-	assert.False(t, mockT.Failed())
-
-	checker.Test("GET", "/nothing")
-	checker.Check()
-
-	checker.HasCookie("some", "cookie")
+	checker.HasCookie("other", "secondcookie")
 	assert.True(t, mockT.Failed())
 }

--- a/httpcheck_test.go
+++ b/httpcheck_test.go
@@ -51,6 +51,8 @@ func (t *testHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		w.Write(body)
 	case "/byte":
 		w.Write([]byte("hello world"))
+	case "/nothing":
+
 	}
 }
 
@@ -259,4 +261,38 @@ func TestCb(t *testing.T) {
 	})
 
 	assert.True(t, called)
+}
+
+func TestCookies(t *testing.T) {
+	mockT := new(testing.T)
+	checker := makeTestChecker(mockT)
+	checker.SetPersistCookies(true)
+	checker.Test("GET", "/some")
+	checker.Check()
+
+	checker.HasCookie("some", "cookie")
+	assert.False(t, mockT.Failed())
+
+	checker.Test("GET", "/nothing")
+	checker.Check()
+
+	checker.HasCookie("some", "cookie")
+	assert.False(t, mockT.Failed())
+}
+
+func TestCookiesDelete(t *testing.T) {
+	mockT := new(testing.T)
+	checker := makeTestChecker(mockT)
+	checker.SetPersistCookies(false)
+	checker.Test("GET", "/some")
+	checker.Check()
+
+	checker.HasCookie("some", "cookie")
+	assert.False(t, mockT.Failed())
+
+	checker.Test("GET", "/nothing")
+	checker.Check()
+
+	checker.HasCookie("some", "cookie")
+	assert.True(t, mockT.Failed())
 }

--- a/httpcheck_test.go
+++ b/httpcheck_test.go
@@ -266,7 +266,8 @@ func TestCb(t *testing.T) {
 func TestCookies(t *testing.T) {
 	mockT := new(testing.T)
 	checker := makeTestChecker(mockT)
-	checker.SetPersistCookies(true)
+	checker.PersistCookie("some")
+
 	checker.Test("GET", "/some")
 	checker.Check()
 
@@ -283,7 +284,7 @@ func TestCookies(t *testing.T) {
 func TestCookiesDelete(t *testing.T) {
 	mockT := new(testing.T)
 	checker := makeTestChecker(mockT)
-	checker.SetPersistCookies(false)
+
 	checker.Test("GET", "/some")
 	checker.Check()
 


### PR DESCRIPTION
Use checker.SetPersistCookies(bool) to set whether cookies should be saved. Default is set to clear cache between cookies in order to maintain backwards compatibility.

Any feedback? :)
