### PR TITLE
Methods HasHeaders and WithHeaders

### DIFF
--- a/httpcheck.go
+++ b/httpcheck.go
@@ -78,6 +78,15 @@ func (c *Checker) stop() {
 	c.server = createServer(c.handler)
 }
 
+func (c *Checker) SetTesting(t *testing.T) *Checker {
+	if t == nil {
+		panic("testing.T is nil")
+	}
+
+	c.t = t
+	return c
+}
+
 // make request /////////////////////////////////////////////////
 
 // If you want to provide you custom http.Request instance, you can do it using this method

--- a/httpcheck.go
+++ b/httpcheck.go
@@ -113,10 +113,29 @@ func (c *Checker) WithHeader(key, value string) *Checker {
 	return c
 }
 
+// Will put a map of headers on request
+func (c *Checker) WithHeaders(headers map[string]string) *Checker {
+	for key, value := range headers {
+		c.request.Header.Set(key, value)
+	}
+	return c
+}
+
 // Will check if response contains header on provided key with provided value
 func (c *Checker) HasHeader(key, expectedValue string) *Checker {
 	value := c.response.Header.Get(key)
 	assert.Exactly(c.t, expectedValue, value)
+
+	return c
+}
+
+// Will check if response contains a provided headers map
+func (c *Checker) HasHeaders(headers map[string]string) *Checker {
+
+	for key, expectedValue := range headers {
+		value := c.response.Header.Get(key)
+		assert.Exactly(c.t, expectedValue, value)
+	}
 
 	return c
 }

--- a/httpcheck_test.go
+++ b/httpcheck_test.go
@@ -83,6 +83,14 @@ func TestNew(t *testing.T) {
 	assert.Exactly(t, t, checker.t)
 }
 
+func TestSetTesting(t *testing.T) {
+	checker := New(nil, &testHandler{})
+	checker.SetTesting(t)
+
+	assert.NotNil(t, checker.t)
+	assert.Exactly(t, t, checker.t)
+}
+
 func TestTest(t *testing.T) {
 	checker := makeTestChecker(t)
 	checker.Test("GET", "/some")

--- a/httpcheck_test.go
+++ b/httpcheck_test.go
@@ -114,6 +114,25 @@ func TestWithHeader(t *testing.T) {
 	assert.Equal(t, "", checker.request.Header.Get("unknown"))
 }
 
+func TestWithHeaders(t *testing.T) {
+	checker := makeTestChecker(t)
+	checker.Test("GET", "/some")
+
+	headers := map[string]string{
+		"key":             "value",
+		"Authorization":   "Token abce-1234",
+		"X-Custom-Header": "custom_value_000",
+	}
+
+	checker.WithHeaders(headers)
+
+	for k, v := range headers {
+		assert.Equal(t, checker.request.Header.Get(k), v)
+	}
+
+	assert.Equal(t, "", checker.request.Header.Get("unknown"))
+}
+
 func TestWithCookie(t *testing.T) {
 	checker := makeTestChecker(t)
 	checker.Test("GET", "/some")
@@ -179,6 +198,38 @@ func TestHasHeader(t *testing.T) {
 
 	checker.HasHeader("unknown", "header")
 	assert.True(t, mockT.Failed())
+}
+
+func TestHasHeaders(t *testing.T) {
+	mockT := new(testing.T)
+	checker := makeTestChecker(mockT)
+	checker.Test("GET", "/some")
+	checker.Check()
+
+	checker.HasHeaders(map[string]string{
+		"some": "header",
+	})
+	assert.False(t, mockT.Failed())
+
+	checker.HasHeaders(map[string]string{
+		"unknown":   "header",
+		"X-Unknown": "abc",
+	})
+	assert.True(t, mockT.Failed())
+}
+
+func TestHasNilHeaders(t *testing.T) {
+	mockT := new(testing.T)
+	checker := makeTestChecker(mockT)
+	checker.Test("GET", "/some")
+
+	// nil is the zero value for maps, so isn't a problem passing nil as parameter to WithHeaders and HasHeaders
+
+	checker.WithHeaders(nil)
+	checker.Check()
+	checker.HasHeaders(nil)
+
+	assert.False(t, mockT.Failed())
 }
 
 func TestHasCookie(t *testing.T) {


### PR DESCRIPTION
There're a lot of cases when you have to do some sort of logic with your headers, so it may be convenient add all your headers as a map after apply business logic in your code. I added 2 new methods:

- WithHeaders()
- HasHeaders()